### PR TITLE
Test the elements map for duplicates rather than the element values list

### DIFF
--- a/src/dktapps/pmforms/CustomForm.php
+++ b/src/dktapps/pmforms/CustomForm.php
@@ -51,7 +51,7 @@ class CustomForm extends BaseForm{
 		parent::__construct($title);
 		$this->elements = array_values($elements);
 		foreach($this->elements as $element){
-			if(isset($this->elements[$element->getName()])){
+			if(isset($this->elementMap[$element->getName()])){
 				throw new \InvalidArgumentException("Multiple elements cannot have the same name, found \"" . $element->getName() . "\" more than once");
 			}
 			$this->elementMap[$element->getName()] = $element;


### PR DESCRIPTION
I ran across this issue while using integers casted as a string for element names. Probably a typo, but here's a fix anyway.